### PR TITLE
remove showQuestionFeedback property from reducer

### DIFF
--- a/src/pages/CurrentQuestionPage.jsx
+++ b/src/pages/CurrentQuestionPage.jsx
@@ -4,10 +4,12 @@ import { CurrentQuestion } from '../components/CurrentQuestion';
 import { AnswerOptions } from '../components/AnswerOptions';
 
 export const CurrentQuestionPage = () => {
-  const showQuestionFeedback = useSelector(
-    state => state.quiz.showQuestionFeedback
+  const currentQuestionIndex = useSelector(
+    state => state.quiz.currentQuestionIndex
   );
-  return showQuestionFeedback ? (
+
+  const answers = useSelector(state => state.quiz.answers);
+  return answers[currentQuestionIndex] != null ? (
     <></>
   ) : (
     <div>

--- a/src/pages/QuestionFeedbackPage.jsx
+++ b/src/pages/QuestionFeedbackPage.jsx
@@ -6,29 +6,16 @@ import { goToNextQuestion } from '../reducers/quiz';
 export const QuestionFeedbackPage = () => {
   const dispatch = useDispatch();
 
-  const showQuestionFeedback = useSelector(
-    state => state.quiz.showQuestionFeedback
-  );
-
   const currentQuestionIndex = useSelector(
     state => state.quiz.currentQuestionIndex
   );
-
   const answers = useSelector(state => state.quiz.answers);
-
-  const quiz = useSelector(state => state.quiz);
-
-  if (!showQuestionFeedback) {
-    return <></>;
-  }
-
-  console.log(quiz);
 
   const handleGoToNextQuestion = () => {
     dispatch(goToNextQuestion());
   };
 
-  if (!showQuestionFeedback) {
+  if (answers[currentQuestionIndex] == null) {
     return <></>;
   }
 

--- a/src/reducers/quiz.js
+++ b/src/reducers/quiz.js
@@ -41,7 +41,6 @@ const initialState = {
   questions,
   answers: [],
   currentQuestionIndex: 0,
-  showQuestionFeedback: false,
   quizOver: false,
 };
 
@@ -99,22 +98,9 @@ export const quiz = createSlice({
     goToNextQuestion: state => {
       if (state.currentQuestionIndex + 1 === state.questions.length) {
         state.quizOver = true;
-        state.showQuestionFeedback = false;
       } else {
         state.currentQuestionIndex += 1;
-        state.showQuestionFeedback = false;
       }
-    },
-
-    /**
-     * Use this action to progress the quiz to the next question. If there's
-     * no more questions (the user was on the final question), set `quizOver`
-     * to `true`.
-     *
-     * This action does not require a payload.
-     */
-    goToQuestionFeedback: state => {
-      state.showQuestionFeedback = true;
     },
 
     /**


### PR DESCRIPTION
This PR removes the `showQuestionFeedback` property that I added to the state. Initially, I added this as a property that we can toggle so we know when to show the `QuestionFeedbackPage`. However, there is a way to know when to do it without having to add a new property.